### PR TITLE
fix(auth): convert usernames to lowercase to prevent false flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = (app) => {
           const oldFileOwner = oldFile.owner.username;
           const prOwner = context.payload.pull_request.user.login;
           let authorized = false;
-          if (oldFileOwner === prOwner) {
+          if (oldFileOwner.toLowerCase() === prOwner.toLowerCase()) {
             authorized = true;
           }
 


### PR DESCRIPTION
There is an issue where if the username in the file is lowercase, yet the user's GitHub username has caps in it, the authorisation return false.

Here is a comment by ReviewMate where this happens: https://github.com/is-a-dev/register/pull/9481#issuecomment-1817841993